### PR TITLE
bugfix: WValue should be 2 bytes

### DIFF
--- a/src/main/java/javax/usb3/enumerated/EDescriptorType.java
+++ b/src/main/java/javax/usb3/enumerated/EDescriptorType.java
@@ -317,8 +317,8 @@ public enum EDescriptorType {
    *              number of descriptors of the indicated type.
    * @return the coded byte for a bRequest field
    */
-  public byte getWValue(byte index) {
-    return (byte) ((byteCode & 0xff) << 8 | (index & 0xff));
+  public short getWValue(byte index) {
+    return (short) ((byteCode & 0xff) << 8 | (index & 0xff));
   }
 
   /**


### PR DESCRIPTION
According to section 9.3 of USB 2.0.pdf the wValue should be two bytes. That's a short in Java terms. This seems to make
`javax.usb3.ri.AUsbDevice.getLanguages()` work for my USB device.

For reference: I believe this was originally broken in commit a3e6c506d8acca0240a5f30c1fc6f6eb0b0a0280. The commit before seems to use `short`, while in that commit it became a `byte`.